### PR TITLE
feat: Added start and end times

### DIFF
--- a/main.py
+++ b/main.py
@@ -20,6 +20,9 @@ def main():
     parser.add_argument('--unique', type=int,
                         help='Removes duplicate images (0 or 1)')
 
+    parser.add_argument('--start-time', type=int, help='Start capturing screenshots at this time (in seconds)', default=None)
+    parser.add_argument('--end-time', type=int, help='End capturing screenshots at this time (in seconds)', default=None)
+
     args = parser.parse_args()
 
     youtube_url = args.youtube_url
@@ -27,8 +30,10 @@ def main():
     output_base_dir = "./outputs"
     output_name = args.output_name
 
+
     video_to_images = VideoToImages(
-        youtube_url, interval, os.path.join(output_base_dir, output_name), output_name)
+        youtube_url, interval, os.path.join(output_base_dir, output_name), output_name, args.start_time, args.end_time)
+
     raw_screenshots_dir = video_to_images.run()
 
     input_directory = f"{raw_screenshots_dir}"

--- a/src/VideoToImages.py
+++ b/src/VideoToImages.py
@@ -5,12 +5,15 @@ from datetime import datetime
 
 
 class VideoToImages:
-    def __init__(self, youtube_url, interval, output_base_dir, output_name):
+    def __init__(self, youtube_url, interval, output_base_dir, output_name, start_time, end_time):
         self.youtube_url = youtube_url
         self.interval = interval
         self.output_base_dir = output_base_dir
         self.output_name = output_name
         self.video_path = None
+        self.start_time = start_time
+        self.end_time = end_time
+        
 
     def create_output_directory(self):
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
@@ -29,12 +32,18 @@ class VideoToImages:
     def capture_screenshots(self):
         cap = cv2.VideoCapture(self.video_path)
         fps = cap.get(cv2.CAP_PROP_FPS)
+
         frame_interval = int(fps * self.interval)
+
+		# Set the start time of the video
+        if self.start_time:
+            cap.set(cv2.CAP_PROP_POS_MSEC, self.start_time * 1000)
 
         frame_count = 0
         screenshot_count = 0
 
-        while cap.isOpened():
+		# Set the end time of the video if specified, otherwise capture all frames
+        while cap.isOpened() and (self.end_time is None or cap.get(cv2.CAP_PROP_POS_MSEC) < self.end_time * 1000):
             ret, frame = cap.read()
             if not ret:
                 break


### PR DESCRIPTION
I added the ability to add start and end time options. Some videos have super lengthy intros that don't need to be screenshotted. Some videos also have a playthrough of the song at the end that also doesn't need to be captured. The start and end times are in seconds.

Here's an example:

`# python main.py https://www.youtube.com/watch?v=kdY_8EdErLc 1 outputFile  --start-time 120 --end-time 460`

View the video here: [Djence Sunflower Guitar Tutorial](https://www.youtube.com/watch?v=kdY_8EdErLc)
